### PR TITLE
Feature(IDE-2251): creates authentication header and sample gql caller

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for actions-stackadapt-audiences destination: postMessage action - all fields 1`] = `
+Object {
+  "query": "SwvXw&[MtMsswfq8J6",
+  "variables": Object {
+    "testType": "SwvXw&[MtMsswfq8J6",
+  },
+}
+`;
+
+exports[`Testing snapshot for actions-stackadapt-audiences destination: postMessage action - required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'actions-stackadapt-audiences'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your StackAdapt GQL API Token
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -6,7 +6,7 @@ import postMessage from './postMessage'
 // TODO: change to production
 export const domain = 'https://sandbox.stackadapt.com/public/graphql'
 const destination: DestinationDefinition<Settings> = {
-  name: 'Stackadapt Audiences',
+  name: 'StackAdapt Audiences',
   slug: 'actions-stackadapt-audiences',
   mode: 'cloud',
 
@@ -21,9 +21,34 @@ const destination: DestinationDefinition<Settings> = {
       }
     },
     testAuthentication: async (request) => {
-      const res = await request(domain)
+      const scopeQuery = `query {
+        tokenInfo {
+          name
+          expiresAt
+          createdAt
+          scopesByAdvertiser {
+            nodes {
+              advertiser {
+                name
+              }
+              scopes
+            }
+          }
+        }
+      }`
+
+      const res = await request(domain, {
+        body: JSON.stringify({ query: scopeQuery })
+      })
       if (res.status !== 200) {
         throw new Error(res.status + res.statusText)
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      const scopes: string[] = JSON.parse(res.content)?.data?.tokenInfo?.scopesByAdvertiser?.nodes?.flatMap(
+        (node: { scopes: string[] }) => node.scopes
+      )
+      if (!scopes.includes('WRITE')) {
+        throw new Error('Please verify your GQL Token or contact support')
       }
     }
   },

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -1,0 +1,44 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+import postMessage from './postMessage'
+
+// TODO: change to production
+export const domain = 'https://sandbox.stackadapt.com/public/graphql'
+const destination: DestinationDefinition<Settings> = {
+  name: 'Stackadapt Audiences',
+  slug: 'actions-stackadapt-audiences',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'custom',
+    fields: {
+      apiKey: {
+        label: 'GraphQL Token',
+        description: 'Your StackAdapt GQL API Token',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: async (request) => {
+      const res = await request(domain)
+      if (res.status !== 200) {
+        throw new Error(res.status + res.statusText)
+      }
+    }
+  },
+  extendRequest: ({ settings }) => {
+    return {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${settings.apiKey}`
+      }
+    }
+  },
+  actions: {
+    postMessage
+  }
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for StackadaptAudiences's postMessage destination action: all fields 1`] = `
+Object {
+  "query": "6Zxm%1",
+  "variables": Object {
+    "testType": "6Zxm%1",
+  },
+}
+`;
+
+exports[`Testing snapshot for StackadaptAudiences's postMessage destination action: required fields 1`] = `Object {}`;

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/index.test.ts
@@ -1,0 +1,9 @@
+// import nock from 'nock'
+// import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+// import Destination from '../../index'
+
+// const testDestination = createTestIntegration(Destination)
+
+// describe('StackadaptAudiences.postMessage', () => {
+//   // TODO: Test your action
+// })

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'postMessage'
+const destinationSlug = 'StackadaptAudiences'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/generated-types.ts
@@ -1,0 +1,12 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The GQL query string
+   */
+  query?: string
+  /**
+   * The variables for GQL query
+   */
+  variables?: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/index.ts
@@ -1,0 +1,44 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { domain } from '..'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Post Message',
+  description: '',
+  fields: {
+    query: {
+      label: 'The GQL query',
+      description: 'The GQL query string',
+      type: 'string',
+      default: `query {
+        tokenInfo {
+          name
+          expiresAt
+          createdAt
+          scopesByAdvertiser {
+            nodes {
+              advertiser {
+                name
+              }
+              scopes
+            }
+          }
+        }
+      }`
+    },
+    variables: {
+      label: 'The GQL query variables',
+      description: 'The variables for GQL query',
+      type: 'object',
+      default: ''
+    }
+  },
+  perform: (request, { payload }) => {
+    return request(domain, {
+      body: JSON.stringify({ query: payload.query, variables: payload.variables })
+    })
+  }
+}
+
+export default action


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._


Sample Query:
```
curl --location --request POST 'http://localhost:<PORT>/authenticate' \
--header 'Content-Type: application/json' \
--data '{ "apiKey": "<API_KEY>" }'


curl --location --request POST 'http://localhost:<PORT>/postMessage' \
--header 'Content-Type: application/json' \
--data '{ "settings": {"apiKey": "<API_KEY>" }}'
```
## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
