### PR TITLE
Feature(IDE-2258): Perform and perform batch functions for Segment audience destination

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - all fields 1`] = `
+Object {
+  "query": "mutation {
+      upsertProfiles(
+        subAdvertiserId: 1,
+        externalProvider: \\"Segment\\",
+        profiles: [{userId:\\"PsAwlRv%\\",testType:\\"PsAwlRv%\\"}]
+      ) {
+        success
+      }
+    }",
+}
+`;
+
+exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardProfile action - required fields 1`] = `
+Object {
+  "query": "mutation {
+      upsertProfiles(
+        subAdvertiserId: 1,
+        externalProvider: \\"Segment\\",
+        profiles: [{userId:\\"PsAwlRv%\\"}]
+      ) {
+        success
+      }
+    }",
+}
+`;
+
 exports[`Testing snapshot for actions-stackadapt-audiences destination: postMessage action - all fields 1`] = `
 Object {
   "query": "SwvXw&[MtMsswfq8J6",

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,7 +6,7 @@ Object {
       upsertProfiles(
         subAdvertiserId: 1,
         externalProvider: \\"Segment\\",
-        profiles: [{userId:\\"PsAwlRv%\\",testType:\\"PsAwlRv%\\"}]
+        profiles: [{testType:\\"PsAwlRv%\\",user_id:\\"PsAwlRv%\\"}]
       ) {
         success
       }
@@ -20,7 +20,7 @@ Object {
       upsertProfiles(
         subAdvertiserId: 1,
         externalProvider: \\"Segment\\",
-        profiles: [{userId:\\"PsAwlRv%\\"}]
+        profiles: [{user_id:\\"PsAwlRv%\\"}]
       ) {
         success
       }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -1,0 +1,116 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Definition from '../../index'
+import { SegmentEvent } from '@segment/actions-core/*'
+
+const testDestination = createTestIntegration(Definition)
+const mockGqlKey = 'test-graphql-key'
+
+const gqlHostUrl = 'https://sandbox.stackadapt.com'
+const gqlPath = '/public/graphql'
+const mockEmail = 'admin@stackadapt.com'
+const mockUserId = 'user-id'
+const mockEmail2 = 'email2@stackadapt.com'
+const mockUserId2 = 'user-id2'
+
+const defaultEventPayload: Partial<SegmentEvent> = {
+  userId: mockUserId,
+  type: 'identify',
+  traits: {
+    email: mockEmail,
+    first_time_buyer: true
+  },
+  context: {
+    personas: {
+      computation_class: 'audience',
+      computation_key: 'first_time_buyer'
+    }
+  }
+}
+
+const batchEventPayload: Partial<SegmentEvent> = {
+  userId: mockUserId2,
+  type: 'identify',
+  traits: {
+    email: mockEmail2
+  }
+}
+
+describe('forwardProfile', () => {
+  it('should translate audience entry/exit into GQL format', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+    const event = createTestEvent(defaultEventPayload)
+    const responses = await testDestination.testAction('forwardProfile', {
+      event,
+      useDefaultMappings: true,
+      settings: { apiKey: mockGqlKey }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(responses[0].request.headers).toMatchInlineSnapshot(`
+      Headers {
+        Symbol(map): Object {
+          "authorization": Array [
+            "Bearer test-graphql-key",
+          ],
+          "content-type": Array [
+            "application/json",
+          ],
+          "user-agent": Array [
+            "Segment (Actions)",
+          ],
+        },
+      }
+    `)
+    expect(requestBody).toMatchInlineSnapshot(`
+      Object {
+        "query": "mutation {
+            upsertProfiles(
+              subAdvertiserId: 1,
+              externalProvider: \\"Segment\\",
+              profiles: [{userId:\\"user-id\\",listId:\\"first_time_buyer\\",action:\\"enter\\",email:\\"admin@stackadapt.com\\"}]
+            ) {
+              success
+            }
+          }",
+      }
+    `)
+  })
+
+  it('should batch multiple profile events into a single request', async () => {
+    let requestBody
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+    const events = [createTestEvent(defaultEventPayload), createTestEvent(batchEventPayload)]
+    const responses = await testDestination.testBatchAction('forwardProfile', {
+      events,
+      useDefaultMappings: true,
+      settings: { apiKey: mockGqlKey }
+    })
+    expect(responses.length).toBe(1)
+    expect(responses[0].status).toBe(200)
+    expect(requestBody).toMatchInlineSnapshot(`
+      Object {
+        "query": "mutation {
+            upsertProfiles(
+              subAdvertiserId: 1,
+              externalProvider: \\"Segment\\",
+              profiles: [{userId:\\"user-id\\",listId:\\"first_time_buyer\\",action:\\"enter\\",email:\\"admin@stackadapt.com\\"},{userId:\\"user-id2\\",email:\\"email2@stackadapt.com\\"}]
+            ) {
+              success
+            }
+          }",
+      }
+    `)
+  })
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -23,7 +23,8 @@ const defaultEventPayload: Partial<SegmentEvent> = {
   context: {
     personas: {
       computation_class: 'audience',
-      computation_key: 'first_time_buyer'
+      computation_key: 'first_time_buyer',
+      computation_id: 'aud_123'
     }
   }
 }
@@ -74,7 +75,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               subAdvertiserId: 1,
               externalProvider: \\"Segment\\",
-              profiles: [{userId:\\"user-id\\",listId:\\"first_time_buyer\\",action:\\"enter\\",email:\\"admin@stackadapt.com\\"}]
+              profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"}]
             ) {
               success
             }
@@ -105,7 +106,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               subAdvertiserId: 1,
               externalProvider: \\"Segment\\",
-              profiles: [{userId:\\"user-id\\",listId:\\"first_time_buyer\\",action:\\"enter\\",email:\\"admin@stackadapt.com\\"},{userId:\\"user-id2\\",email:\\"email2@stackadapt.com\\"}]
+              profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",user_id:\\"user-id2\\"}]
             ) {
               success
             }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -6,17 +6,18 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
   const endpoint = 'https://sandbox.stackadapt.com/public/graphql'
   const profileUpdates = events.map((event) => {
     const profile: Record<string, string | number | undefined> = {
-      userId: event.user_id
+      user_id: event.user_id
     }
     if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
       // This is an audience enter/exit event, there should be a boolean flag in the traits indicating if the user entered or exited the audience
       // We need to translate it into an enter or exit action as expected by the profile upsert GraphQL mutation
+      profile.audience_id = event.segment_computation_id
       const audienceKey = event.segment_computation_key
-      profile.listId = audienceKey
+      profile.audience_name = audienceKey
       profile.action = event.traits[audienceKey] ? 'enter' : 'exit'
       delete event.traits[audienceKey] // Don't need to include the boolean flag in the GQL payload
     }
-    return { ...profile, ...event.traits }
+    return { ...event.traits, ...profile }
   })
 
   // TODO: Add setting for advertiser ID and replace hardcoded value with it

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -1,0 +1,35 @@
+import { RequestClient } from '@segment/actions-core'
+import { Payload } from './generated-types'
+
+export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
+  // TODO: switch to production endpoint
+  const endpoint = 'https://sandbox.stackadapt.com/public/graphql'
+  const profileUpdates = events.map((event) => {
+    const profile: Record<string, string | number | undefined> = {
+      userId: event.user_id
+    }
+    if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
+      // This is an audience enter/exit event, there should be a boolean flag in the traits indicating if the user entered or exited the audience
+      // We need to translate it into an enter or exit action as expected by the profile upsert GraphQL mutation
+      const audienceKey = event.segment_computation_key
+      profile.listId = audienceKey
+      profile.action = event.traits[audienceKey] ? 'enter' : 'exit'
+      delete event.traits[audienceKey] // Don't need to include the boolean flag in the GQL payload
+    }
+    return { ...profile, ...event.traits }
+  })
+
+  // TODO: Add setting for advertiser ID and replace hardcoded value with it
+  const mutation = `mutation {
+      upsertProfiles(
+        subAdvertiserId: 1,
+        externalProvider: "Segment",
+        profiles: ${JSON.stringify(profileUpdates).replace(/"([^"]+)":/g, '$1:') /* Remove quotes around keys */}
+      ) {
+        success
+      }
+    }`
+  return await request(endpoint, {
+    body: JSON.stringify({ query: mutation })
+  })
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -1,9 +1,8 @@
 import { RequestClient } from '@segment/actions-core'
 import { Payload } from './generated-types'
+import { domain } from '..'
 
 export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
-  // TODO: switch to production endpoint
-  const endpoint = 'https://sandbox.stackadapt.com/public/graphql'
   const profileUpdates = events.map((event) => {
     const profile: Record<string, string | number | undefined> = {
       user_id: event.user_id
@@ -30,7 +29,7 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
         success
       }
     }`
-  return await request(endpoint, {
+  return await request(domain, {
     body: JSON.stringify({ query: mutation })
   })
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
@@ -1,0 +1,26 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The properties of the user.
+   */
+  traits?: {
+    [k: string]: unknown
+  }
+  /**
+   * The ID of the user in Segment
+   */
+  user_id?: string
+  /**
+   * When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.
+   */
+  enable_batching: boolean
+  /**
+   * Segment computation class used to determine if input event is from an Engage Audience'.
+   */
+  segment_computation_class?: string
+  /**
+   * For audience enter/exit events, this will be the audience key.
+   */
+  segment_computation_key?: string
+}

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
@@ -20,6 +20,10 @@ export interface Payload {
    */
   segment_computation_class?: string
   /**
+   * For audience enter/exit events, this will be the audience ID.
+   */
+  segment_computation_id?: string
+  /**
    * For audience enter/exit events, this will be the audience key.
    */
   segment_computation_key?: string

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -48,6 +48,15 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.context.personas.computation_class'
       }
     },
+    segment_computation_id: {
+      label: 'Segment Computation ID',
+      description: 'For audience enter/exit events, this will be the audience ID.',
+      type: 'string',
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.context.personas.computation_id'
+      }
+    },
     segment_computation_key: {
       label: 'Segment Computation Key',
       description: 'For audience enter/exit events, this will be the audience key.',

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -1,0 +1,69 @@
+import { ActionDefinition } from '@segment/actions-core'
+import { Payload } from './generated-types'
+import { Settings } from '../generated-types'
+import { performForwardProfiles } from './functions'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Forward Profile',
+  description: 'Forward new or updated user profile to StackAdapt',
+  defaultSubscription: 'event = "Identify"',
+  fields: {
+    traits: {
+      label: 'User Properties',
+      type: 'object',
+      description: 'The properties of the user.',
+      default: {
+        '@path': '$.traits'
+      }
+    },
+    user_id: {
+      label: 'Segment User ID',
+      description: 'The ID of the user in Segment',
+      type: 'string',
+      default: {
+        // By default we want to use the permanent user id that's consistent across a customer's lifetime.
+        // But if we don't have that we can fall back to the anonymous id
+        '@if': {
+          exists: { '@path': '$.userId' },
+          then: { '@path': '$.userId' },
+          else: { '@path': '$.anonymousId' }
+        }
+      }
+    },
+    enable_batching: {
+      type: 'boolean',
+      label: 'Batch Profiles',
+      unsafe_hidden: true,
+      description:
+        'When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.',
+      required: true,
+      default: true
+    },
+    segment_computation_class: {
+      label: 'Segment Computation Class',
+      description: "Segment computation class used to determine if input event is from an Engage Audience'.",
+      type: 'string',
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.context.personas.computation_class'
+      }
+    },
+    segment_computation_key: {
+      label: 'Segment Computation Key',
+      description: 'For audience enter/exit events, this will be the audience key.',
+      type: 'string',
+      unsafe_hidden: true,
+      default: {
+        '@path': '$.context.personas.computation_key'
+      }
+    }
+  },
+  perform: async (request, { payload }) => {
+    return await performForwardProfiles(request, [payload])
+  },
+  performBatch: async (request, { payload }) => {
+    return await performForwardProfiles(request, payload)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 import postMessage from './postMessage'
+import forwardProfile from './forwardProfile'
 
 // TODO: change to production
 export const domain = 'https://sandbox.stackadapt.com/public/graphql'
@@ -62,7 +63,8 @@ const destination: DestinationDefinition<Settings> = {
     }
   },
   actions: {
-    postMessage
+    postMessage,
+    forwardProfile
   }
 }
 


### PR DESCRIPTION
[IDE-2258](https://stackadapt.atlassian.net/browse/IDE-2258)

Added `forwardProfiles` action which handles `Identify` events. Capable of handling both profile information as well as audience enter/exit events and forwarding the appropriate request to the `upsertProfiles` GraphQL mutation.

Also added tests for `forwardProfiles`

## Testing

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
  - Not possible to test end-to-end until the source pod and GraphQL mutation are implemented

[IDE-2258]: https://stackadapt.atlassian.net/browse/IDE-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ