### PR TITLE
Feature(IDE-2305): Implement onDelete handler

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "query": "mutation {
       upsertProfiles(
         subAdvertiserId: 1,
-        externalProvider: \\"Segment\\",
+        externalProvider: \\"segmentio\\",
         profiles: [{testType:\\"PsAwlRv%\\",user_id:\\"PsAwlRv%\\"}]
       ) {
         success
@@ -19,7 +19,7 @@ Object {
   "query": "mutation {
       upsertProfiles(
         subAdvertiserId: 1,
-        externalProvider: \\"Segment\\",
+        externalProvider: \\"segmentio\\",
         profiles: [{user_id:\\"PsAwlRv%\\"}]
       ) {
         success

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
@@ -44,7 +44,7 @@ describe('onDelete', () => {
         "query": "mutation {
             deleteProfiles(
               subAdvertiserId: 1,
-              externalProvider: \\"Segment\\",
+              externalProvider: \\"segmentio\\",
               userIds: [\\"user-id\\"]
             ) {
               success

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/index.test.ts
@@ -1,0 +1,72 @@
+import nock from 'nock'
+import { createTestEvent, createTestIntegration, DecoratedResponse } from '@segment/actions-core'
+import Definition from '../index'
+import { SegmentEvent } from '@segment/actions-core/*'
+
+const testDestination = createTestIntegration(Definition)
+const mockGqlKey = 'test-graphql-key'
+
+const gqlHostUrl = 'https://sandbox.stackadapt.com'
+const gqlPath = '/public/graphql'
+const mockUserId = 'user-id'
+const mockAnonymousId = 'anonymous-id'
+
+const defaultEventPayload: Partial<SegmentEvent> = {
+  userId: mockUserId
+}
+
+const anonymousIdPayload: Partial<SegmentEvent> = {
+  userId: mockAnonymousId
+}
+
+describe('onDelete', () => {
+  it('should send GraphQL mutation with correct headers when delete event triggered', async () => {
+    let requestBody
+    nock(gqlHostUrl, {
+      reqheaders: {
+        Authorization: `Bearer ${mockGqlKey}`
+      }
+    })
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+    const event = createTestEvent(defaultEventPayload)
+    if (!testDestination.onDelete) {
+      throw new Error('onDelete function not implemented')
+    }
+    const result = await testDestination.onDelete(event, { apiKey: mockGqlKey })
+    const response = result as DecoratedResponse
+    expect(response.status).toBe(200)
+    expect(requestBody).toMatchInlineSnapshot(`
+      Object {
+        "query": "mutation {
+            deleteProfiles(
+              subAdvertiserId: 1,
+              externalProvider: \\"Segment\\",
+              userIds: [\\"user-id\\"]
+            ) {
+              success
+            }
+          }",
+      }
+    `)
+  })
+
+  it('should fallback to anonymous ID if user ID is unknown', async () => {
+    let requestBody: { query: string } = { query: '' }
+    nock(gqlHostUrl)
+      .post(gqlPath, (body) => {
+        requestBody = body
+        return body
+      })
+      .reply(200, { data: { success: true } })
+    const event = createTestEvent(anonymousIdPayload)
+    if (!testDestination.onDelete) {
+      throw new Error('onDelete function not implemented')
+    }
+    await testDestination.onDelete(event, { apiKey: mockGqlKey })
+    expect(requestBody.query).toMatch(new RegExp(`userIds: \\["${mockAnonymousId}"\\]`))
+  })
+})

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -74,7 +74,7 @@ describe('forwardProfile', () => {
         "query": "mutation {
             upsertProfiles(
               subAdvertiserId: 1,
-              externalProvider: \\"Segment\\",
+              externalProvider: \\"segmentio\\",
               profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"}]
             ) {
               success
@@ -105,7 +105,7 @@ describe('forwardProfile', () => {
         "query": "mutation {
             upsertProfiles(
               subAdvertiserId: 1,
-              externalProvider: \\"Segment\\",
+              externalProvider: \\"segmentio\\",
               profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",user_id:\\"user-id2\\"}]
             ) {
               success

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -23,7 +23,7 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
   const mutation = `mutation {
       upsertProfiles(
         subAdvertiserId: 1,
-        externalProvider: "Segment",
+        externalProvider: "segmentio",
         profiles: ${JSON.stringify(profileUpdates).replace(/"([^"]+)":/g, '$1:') /* Remove quotes around keys */}
       ) {
         success

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -68,7 +68,7 @@ const destination: DestinationDefinition<Settings> = {
     const query = `mutation {
       deleteProfiles(
         subAdvertiserId: 1,
-        externalProvider: "Segment",
+        externalProvider: "segmentio",
         userIds: ["${userId}"]
       ) {
         success

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/index.ts
@@ -62,6 +62,24 @@ const destination: DestinationDefinition<Settings> = {
       }
     }
   },
+  onDelete: async (request, { payload }) => {
+    const userId = payload.userId ?? payload.anonymousId
+    // TODO: Add setting for advertiser ID and replace hardcoded value with it
+    const query = `mutation {
+      deleteProfiles(
+        subAdvertiserId: 1,
+        externalProvider: "Segment",
+        userIds: ["${userId}"]
+      ) {
+        success
+      }
+    }`
+    return request(domain, {
+      body: JSON.stringify({
+        query
+      })
+    })
+  },
   actions: {
     postMessage,
     forwardProfile


### PR DESCRIPTION
[IDE-2305](https://stackadapt.atlassian.net/browse/IDE-2305)

Implement `onDelete` handler to send mutation to delete profiles that are deleted on Segment's side, and add automated tests to cover it.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
  - Will test end-to-end once GraphQL mutation is implemented
- [ ] [Segmenters] Tested in the staging environment


[IDE-2305]: https://stackadapt.atlassian.net/browse/IDE-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ