### PR TITLE
Feature(IDE-2338): Force profile field keys to camelCase

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,7 +6,7 @@ Object {
       upsertProfiles(
         subAdvertiserId: 1,
         externalProvider: \\"segmentio\\",
-        profiles: [{testType:\\"PsAwlRv%\\",user_id:\\"PsAwlRv%\\"}]
+        profiles: [{testType:\\"PsAwlRv%\\",userId:\\"PsAwlRv%\\"}]
       ) {
         success
       }
@@ -20,7 +20,7 @@ Object {
       upsertProfiles(
         subAdvertiserId: 1,
         externalProvider: \\"segmentio\\",
-        profiles: [{user_id:\\"PsAwlRv%\\"}]
+        profiles: [{userId:\\"PsAwlRv%\\"}]
       ) {
         success
       }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -75,7 +75,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               subAdvertiserId: 1,
               externalProvider: \\"segmentio\\",
-              profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"}]
+              profiles: [{email:\\"admin@stackadapt.com\\",userId:\\"user-id\\",audienceId:\\"aud_123\\",audienceName:\\"first_time_buyer\\",action:\\"enter\\"}]
             ) {
               success
             }
@@ -106,7 +106,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               subAdvertiserId: 1,
               externalProvider: \\"segmentio\\",
-              profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",user_id:\\"user-id2\\"}]
+              profiles: [{email:\\"admin@stackadapt.com\\",userId:\\"user-id\\",audienceId:\\"aud_123\\",audienceName:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",userId:\\"user-id2\\"}]
             ) {
               success
             }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -5,18 +5,23 @@ import { domain } from '..'
 export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
   const profileUpdates = events.map((event) => {
     const profile: Record<string, string | number | undefined> = {
-      user_id: event.user_id
+      userId: event.user_id
     }
     if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
       // This is an audience enter/exit event, there should be a boolean flag in the traits indicating if the user entered or exited the audience
       // We need to translate it into an enter or exit action as expected by the profile upsert GraphQL mutation
-      profile.audience_id = event.segment_computation_id
+      profile.audienceId = event.segment_computation_id
       const audienceKey = event.segment_computation_key
-      profile.audience_name = audienceKey
+      profile.audienceName = audienceKey
       profile.action = event.traits[audienceKey] ? 'enter' : 'exit'
       delete event.traits[audienceKey] // Don't need to include the boolean flag in the GQL payload
     }
-    return { ...event.traits, ...profile }
+    // Convert trait keys to camelCase
+    const traits = Object.keys(event?.traits ?? {}).reduce((acc: Record<string, unknown>, key) => {
+      acc[toCamelCase(key)] = event?.traits?.[key]
+      return acc
+    }, {})
+    return { ...traits, ...profile }
   })
 
   // TODO: Add setting for advertiser ID and replace hardcoded value with it
@@ -32,4 +37,13 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
   return await request(domain, {
     body: JSON.stringify({ query: mutation })
   })
+}
+
+// From https://www.30secondsofcode.org/js/s/string-case-conversion/
+function toCamelCase(str: string) {
+  const s = str
+    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+    ?.map((x) => x.slice(0, 1).toUpperCase() + x.slice(1).toLowerCase())
+    .join('')
+  return s ? s.slice(0, 1).toLowerCase() + s.slice(1) : ''
 }


### PR DESCRIPTION
[IDE-2338](https://stackadapt.atlassian.net/browse/IDE-2338)

Force conversion of profile keys to camelCase in order to be consistent with GraphQL property names.

## Testing

Updated existing tests to account for change to profile keys

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[IDE-2338]: https://stackadapt.atlassian.net/browse/IDE-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ