### PR TITLE
Feature(IDE-2335): Dynamic field for Audience ID that loads options from our API

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
 Object {
   "query": "mutation {
       upsertProfiles(
-        subAdvertiserId: 1,
+        subAdvertiserId: PsAwlRv%,
         externalProvider: \\"segmentio\\",
         profiles: [{testType:\\"PsAwlRv%\\",user_id:\\"PsAwlRv%\\"}]
       ) {
@@ -18,7 +18,7 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
 Object {
   "query": "mutation {
       upsertProfiles(
-        subAdvertiserId: 1,
+        subAdvertiserId: PsAwlRv%,
         externalProvider: \\"segmentio\\",
         profiles: [{user_id:\\"PsAwlRv%\\"}]
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -12,6 +12,8 @@ const mockEmail = 'admin@stackadapt.com'
 const mockUserId = 'user-id'
 const mockEmail2 = 'email2@stackadapt.com'
 const mockUserId2 = 'user-id2'
+const mockAdvertiserId = '23'
+const mockMappings = { advertiser_id: mockAdvertiserId }
 
 const defaultEventPayload: Partial<SegmentEvent> = {
   userId: mockUserId,
@@ -50,6 +52,7 @@ describe('forwardProfile', () => {
     const responses = await testDestination.testAction('forwardProfile', {
       event,
       useDefaultMappings: true,
+      mapping: mockMappings,
       settings: { apiKey: mockGqlKey }
     })
     expect(responses.length).toBe(1)
@@ -73,7 +76,7 @@ describe('forwardProfile', () => {
       Object {
         "query": "mutation {
             upsertProfiles(
-              subAdvertiserId: 1,
+              subAdvertiserId: ${mockAdvertiserId},
               externalProvider: \\"segmentio\\",
               profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"}]
             ) {
@@ -96,6 +99,7 @@ describe('forwardProfile', () => {
     const responses = await testDestination.testBatchAction('forwardProfile', {
       events,
       useDefaultMappings: true,
+      mapping: mockMappings,
       settings: { apiKey: mockGqlKey }
     })
     expect(responses.length).toBe(1)
@@ -104,7 +108,7 @@ describe('forwardProfile', () => {
       Object {
         "query": "mutation {
             upsertProfiles(
-              subAdvertiserId: 1,
+              subAdvertiserId: ${mockAdvertiserId},
               externalProvider: \\"segmentio\\",
               profiles: [{email:\\"admin@stackadapt.com\\",user_id:\\"user-id\\",audience_id:\\"aud_123\\",audience_name:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",user_id:\\"user-id2\\"}]
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -3,6 +3,7 @@ import { Payload } from './generated-types'
 import { domain } from '..'
 
 export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
+  const advertiserId = events[0].advertiser_id
   const profileUpdates = events.map((event) => {
     const profile: Record<string, string | number | undefined> = {
       user_id: event.user_id
@@ -22,7 +23,7 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
   // TODO: Add setting for advertiser ID and replace hardcoded value with it
   const mutation = `mutation {
       upsertProfiles(
-        subAdvertiserId: 1,
+        subAdvertiserId: ${advertiserId},
         externalProvider: "segmentio",
         profiles: ${JSON.stringify(profileUpdates).replace(/"([^"]+)":/g, '$1:') /* Remove quotes around keys */}
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
@@ -27,4 +27,8 @@ export interface Payload {
    * For audience enter/exit events, this will be the audience key.
    */
   segment_computation_key?: string
+  /**
+   * The StackAdapt audience to add the profile to.
+   */
+  advertiser_id: string
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -1,7 +1,30 @@
-import { ActionDefinition } from '@segment/actions-core'
+import { ActionDefinition, APIError, DynamicFieldResponse } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { Settings } from '../generated-types'
 import { performForwardProfiles } from './functions'
+import { domain } from '..'
+
+interface Advertiser {
+  id: string
+  name: string
+}
+
+interface TokenInfoResponse {
+  data: {
+    tokenInfo: {
+      scopesByAdvertiser: {
+        nodes: {
+          advertiser: Advertiser
+          scopes: string[]
+        }[]
+        pageInfo: {
+          hasNextPage: boolean
+          endCursor: string
+        }
+      }
+    }
+  }
+}
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward Profile',
@@ -64,6 +87,59 @@ const action: ActionDefinition<Settings, Payload> = {
       unsafe_hidden: true,
       default: {
         '@path': '$.context.personas.computation_key'
+      }
+    },
+    advertiser_id: {
+      label: 'Audience',
+      description: 'The StackAdapt audience to add the profile to.',
+      type: 'string',
+      required: true,
+      dynamic: true
+    }
+  },
+  dynamicFields: {
+    advertiser_id: async (request, { page }): Promise<DynamicFieldResponse> => {
+      // Even though its typescript type is string, in testing I found page can be a number so I use == here
+      page = !page || page == '1' ? '' : page
+      try {
+        const query = `query {
+          tokenInfo {
+            scopesByAdvertiser(after: "${page}") {
+              nodes {
+                advertiser {
+                  id
+                  name
+                }
+                scopes
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }`
+        const response = await request<TokenInfoResponse>(domain, {
+          body: JSON.stringify({ query })
+        })
+        const scopesByAdvertiser = response.data.data.tokenInfo.scopesByAdvertiser
+        const choices = scopesByAdvertiser.nodes
+          .filter((advertiserEntry) => advertiserEntry.scopes.includes('WRITE'))
+          .map((advertiserEntry) => ({ value: advertiserEntry.advertiser.id, label: advertiserEntry.advertiser.name }))
+        const nextPage = scopesByAdvertiser.pageInfo.hasNextPage ? scopesByAdvertiser.pageInfo.endCursor : undefined
+        return {
+          choices,
+          nextPage
+        }
+      } catch (error) {
+        return {
+          choices: [],
+          nextPage: '',
+          error: {
+            message: (error as APIError).message ?? 'Unknown error',
+            code: (error as APIError).status?.toString() ?? 'Unknown error'
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
[IDE-2335]()

Add dynamic field that allows customers to select the advertiser ID from the advertisers their API key has write permissions to.

I've reached out to Joe to see if we can have a dynamic field as a global setting, which would be required to make this setting accessible from the `onDelete` function without losing the ability to pull the list of advertisers from the API.

## Testing

Modified tests to provide coverage

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
