### PR TITLE
Feature(IDE-2356): Handle alias events

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -143,7 +143,7 @@ describe('forwardProfile', () => {
             upsertProfiles(
               subAdvertiserId: 1,
               externalProvider: \\"segmentio\\",
-              profiles: [{user_id:\\"user-id\\",previous_id:\\"user-id2\\"}]
+              profiles: [{userId:\\"user-id\\",previousId:\\"user-id2\\"}]
             ) {
               success
             }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -7,7 +7,9 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
     const profile: Record<string, string | number | undefined> = {
       user_id: event.user_id
     }
-    if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
+    if (event.event_type === 'alias') {
+      profile.previous_id = event.previous_id
+    } else if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
       // This is an audience enter/exit event, there should be a boolean flag in the traits indicating if the user entered or exited the audience
       // We need to translate it into an enter or exit action as expected by the profile upsert GraphQL mutation
       profile.audience_id = event.segment_computation_id

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -8,7 +8,7 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
       userId: event.user_id
     }
     if (event.event_type === 'alias') {
-      profile.previous_id = event.previous_id
+      profile.previousId = event.previous_id
     } else if (event.segment_computation_class === 'audience' && event.traits && event.segment_computation_key) {
       // This is an audience enter/exit event, there should be a boolean flag in the traits indicating if the user entered or exited the audience
       // We need to translate it into an enter or exit action as expected by the profile upsert GraphQL mutation

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/generated-types.ts
@@ -12,6 +12,14 @@ export interface Payload {
    */
   user_id?: string
   /**
+   * The user's previous ID, for alias events
+   */
+  previous_id?: string
+  /**
+   * The Segment event type (identify, alias, etc.)
+   */
+  event_type?: string
+  /**
    * When enabled, Segment will batch profiles together and send them to StackAdapt in a single request.
    */
   enable_batching: boolean

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/index.ts
@@ -6,7 +6,7 @@ import { performForwardProfiles } from './functions'
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Forward Profile',
   description: 'Forward new or updated user profile to StackAdapt',
-  defaultSubscription: 'event = "Identify"',
+  defaultSubscription: 'type = "identify" or type = "alias"',
   fields: {
     traits: {
       label: 'User Properties',
@@ -28,6 +28,22 @@ const action: ActionDefinition<Settings, Payload> = {
           then: { '@path': '$.userId' },
           else: { '@path': '$.anonymousId' }
         }
+      }
+    },
+    previous_id: {
+      label: 'Previous ID',
+      type: 'string',
+      description: "The user's previous ID, for alias events",
+      default: {
+        '@path': '$.previousId'
+      }
+    },
+    event_type: {
+      label: 'Event Type',
+      description: 'The Segment event type (identify, alias, etc.)',
+      type: 'string',
+      default: {
+        '@path': '$.type'
       }
     },
     enable_batching: {


### PR DESCRIPTION
[IDE-2356](https://stackadapt.atlassian.net/browse/IDE-2356)

Segment can send an alias event which changes the user's Segment user ID. We need to handle this by sending both the old and the new ID to the server.

## Testing

Added additional unit test to validate that a simulated alias event produces the expected GQL mutation request.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment


[IDE-2356]: https://stackadapt.atlassian.net/browse/IDE-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ