### PR TITLE
Feature(IDE-2546): Profile and audience mappings

### DIFF
--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -4,11 +4,36 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
 Object {
   "query": "mutation {
       upsertProfiles(
-        subAdvertiserId: PsAwlRv%,
+        advertiserId: PsAwlRv%,
         externalProvider: \\"segmentio\\",
-        profiles: [{testType:\\"PsAwlRv%\\",userId:\\"PsAwlRv%\\"}]
+        syncId: \\"f24e8ba158f2f09eaec6035ece3124e3a93a286d850f5a8a7d4403681b8748eb\\",
+        profiles: \\"[{\\\\\\"testType\\\\\\":\\\\\\"PsAwlRv%\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\"}]\\"
       ) {
-        success
+        userErrors {
+          message
+        }
+      }
+      upsertProfileMapping(
+        input: {
+          advertiserId: PsAwlRv%,
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappableType: \\"segmentio\\",
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      upsertExternalAudienceMapping(
+        input: {
+          advertiserId: PsAwlRv%,
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappableType: \\"segmentio\\"
+        }
+      ) {
+        userErrors {
+          message
+        }
       }
     }",
 }
@@ -18,11 +43,36 @@ exports[`Testing snapshot for actions-stackadapt-audiences destination: forwardP
 Object {
   "query": "mutation {
       upsertProfiles(
-        subAdvertiserId: PsAwlRv%,
+        advertiserId: PsAwlRv%,
         externalProvider: \\"segmentio\\",
-        profiles: [{userId:\\"PsAwlRv%\\"}]
+        syncId: \\"6a621eeab9a88ec2f054989bccddeec1d63de12fbc7ac74b2a2a67ab5679033f\\",
+        profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"PsAwlRv%\\\\\\"}]\\"
       ) {
-        success
+        userErrors {
+          message
+        }
+      }
+      upsertProfileMapping(
+        input: {
+          advertiserId: PsAwlRv%,
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappableType: \\"segmentio\\",
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      upsertExternalAudienceMapping(
+        input: {
+          advertiserId: PsAwlRv%,
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappableType: \\"segmentio\\"
+        }
+      ) {
+        userErrors {
+          message
+        }
       }
     }",
 }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -27,7 +27,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {
@@ -66,7 +66,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -16,7 +16,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"testType\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -55,7 +55,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -96,7 +96,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -153,7 +153,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -210,7 +210,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -35,7 +35,9 @@ const batchEventPayload: Partial<SegmentEvent> = {
   userId: mockUserId2,
   type: 'identify',
   traits: {
-    email: mockEmail2
+    email: mockEmail2,
+    custom_field: 'value',
+    number_custom_field: 123
   }
 }
 
@@ -82,11 +84,36 @@ describe('forwardProfile', () => {
       Object {
         "query": "mutation {
             upsertProfiles(
-              subAdvertiserId: ${mockAdvertiserId},
+              advertiserId: 23,
               externalProvider: \\"segmentio\\",
-              profiles: [{email:\\"admin@stackadapt.com\\",userId:\\"user-id\\",audienceId:\\"aud_123\\",audienceName:\\"first_time_buyer\\",action:\\"enter\\"}]
+              syncId: \\"9e1d2ce099d4f67eea85e3a8e692db14e1e903365304f871c304a1d718cfe28c\\",
+              profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"}]\\"
             ) {
-              success
+              userErrors {
+                message
+              }
+            }
+            upsertProfileMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappableType: \\"segmentio\\",
+              }
+            ) {
+              userErrors {
+                message
+              }
+            }
+            upsertExternalAudienceMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappableType: \\"segmentio\\"
+              }
+            ) {
+              userErrors {
+                message
+              }
             }
           }",
       }
@@ -114,11 +141,36 @@ describe('forwardProfile', () => {
       Object {
         "query": "mutation {
             upsertProfiles(
-              subAdvertiserId: ${mockAdvertiserId},
+              advertiserId: 23,
               externalProvider: \\"segmentio\\",
-              profiles: [{email:\\"admin@stackadapt.com\\",userId:\\"user-id\\",audienceId:\\"aud_123\\",audienceName:\\"first_time_buyer\\",action:\\"enter\\"},{email:\\"email2@stackadapt.com\\",userId:\\"user-id2\\"}]
+              syncId: \\"568869a402020aef80f7079205c73a4a5e73b3ecaf2e7e95b47a47f750887ac1\\",
+              profiles: \\"[{\\\\\\"email\\\\\\":\\\\\\"admin@stackadapt.com\\\\\\",\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"audienceId\\\\\\":\\\\\\"aud_123\\\\\\",\\\\\\"audienceName\\\\\\":\\\\\\"first_time_buyer\\\\\\",\\\\\\"action\\\\\\":\\\\\\"enter\\\\\\"},{\\\\\\"email\\\\\\":\\\\\\"email2@stackadapt.com\\\\\\",\\\\\\"customField\\\\\\":\\\\\\"value\\\\\\",\\\\\\"numberCustomField\\\\\\":123,\\\\\\"userId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
             ) {
-              success
+              userErrors {
+                message
+              }
+            }
+            upsertProfileMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappableType: \\"segmentio\\",
+              }
+            ) {
+              userErrors {
+                message
+              }
+            }
+            upsertExternalAudienceMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappableType: \\"segmentio\\"
+              }
+            ) {
+              userErrors {
+                message
+              }
             }
           }",
       }
@@ -137,6 +189,7 @@ describe('forwardProfile', () => {
     const responses = await testDestination.testAction('forwardProfile', {
       event,
       useDefaultMappings: true,
+      mapping: mockMappings,
       settings: { apiKey: mockGqlKey }
     })
     expect(responses.length).toBe(1)
@@ -145,11 +198,36 @@ describe('forwardProfile', () => {
       Object {
         "query": "mutation {
             upsertProfiles(
-              subAdvertiserId: 1,
+              advertiserId: 23,
               externalProvider: \\"segmentio\\",
-              profiles: [{userId:\\"user-id\\",previousId:\\"user-id2\\"}]
+              syncId: \\"b9612b9eb0ade5b30e0f474e03e54449e0d108e09306aa1afdf92e2a6267146e\\",
+              profiles: \\"[{\\\\\\"userId\\\\\\":\\\\\\"user-id\\\\\\",\\\\\\"previousId\\\\\\":\\\\\\"user-id2\\\\\\"}]\\"
             ) {
-              success
+              userErrors {
+                message
+              }
+            }
+            upsertProfileMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappableType: \\"segmentio\\",
+              }
+            ) {
+              userErrors {
+                message
+              }
+            }
+            upsertExternalAudienceMapping(
+              input: {
+                advertiserId: 23,
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappableType: \\"segmentio\\"
+              }
+            ) {
+              userErrors {
+                message
+              }
             }
           }",
       }

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -107,7 +107,7 @@ describe('forwardProfile', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -164,7 +164,7 @@ describe('forwardProfile', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -221,7 +221,7 @@ describe('forwardProfile', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceID\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"AudienceName\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"data_type\\\\\\":\\\\\\"string\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -10,7 +10,7 @@ const standardFields = new Set([
   'firstName',
   'lastName',
   'phone',
-  'emailMarketingStatus',
+  'marketingStatus',
   'company',
   'gender',
   'city',

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -129,7 +129,7 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
   for (const field of customFields) {
     mappingSchema.push({
       incoming_key: field,
-      destination_key: field,
+      destination_key: field === 'userId' ? 'external_id' : field,
       data_type: fieldTypes[field] ?? 'string',
       is_pii: false
     })

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -1,8 +1,52 @@
 import { RequestClient } from '@segment/actions-core'
 import { Payload } from './generated-types'
 import { domain } from '..'
+import { createHash } from 'crypto'
+
+const EXTERNAL_PROVIDER = 'segmentio'
+
+const standardFields = new Set([
+  'email',
+  'firstName',
+  'lastName',
+  'phone',
+  'emailMarketingStatus',
+  'company',
+  'gender',
+  'city',
+  'state',
+  'country',
+  'timezone',
+  'postalCode',
+  'birthDay',
+  'birthMonth',
+  'address',
+  'previousId'
+])
+const audienceMapping = stringifyJsonWithEscapedQuotes([
+  {
+    incoming_key: 'audienceId',
+    destination_key: 'AudienceID',
+    data_type: 'string'
+  },
+  {
+    incoming_key: 'audienceName',
+    destination_key: 'AudienceName',
+    data_type: 'string'
+  }
+])
+
+interface Mapping {
+  incoming_key: string
+  destination_key: string
+  data_type: string
+  is_pii: boolean
+}
 
 export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
+  if (events.length === 0) return
+  const fieldsToMap: Set<string> = new Set(['userId'])
+  const fieldTypes: Record<string, string> = { userId: 'string' }
   const advertiserId = events[0].advertiser_id
   const profileUpdates = events.map((event) => {
     const profile: Record<string, string | number | undefined> = {
@@ -19,27 +63,93 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
       profile.action = event.traits[audienceKey] ? 'enter' : 'exit'
       delete event.traits[audienceKey] // Don't need to include the boolean flag in the GQL payload
     }
-    // Convert trait keys to camelCase
+    // Convert trait keys to camelCase and capture any non-standard fields
     const traits = Object.keys(event?.traits ?? {}).reduce((acc: Record<string, unknown>, key) => {
-      acc[toCamelCase(key)] = event?.traits?.[key]
+      const camelCaseKey = toCamelCase(key)
+      acc[camelCaseKey] = event?.traits?.[key]
+      if (!standardFields.has(camelCaseKey)) {
+        fieldsToMap.add(camelCaseKey)
+        // Field type should be the most specific type of the values we've seen so far, use string if there is a conflict of types
+        if (event?.traits?.[key] || event?.traits?.[key] === 0) {
+          const type = getType(event.traits[key])
+          if (fieldTypes[camelCaseKey] && fieldTypes[camelCaseKey] !== type) {
+            fieldTypes[camelCaseKey] = 'string'
+          } else {
+            fieldTypes[camelCaseKey] = type
+          }
+        }
+      }
       return acc
     }, {})
     return { ...traits, ...profile }
   })
 
-  // TODO: Add setting for advertiser ID and replace hardcoded value with it
+  const profiles = stringifyJsonWithEscapedQuotes(profileUpdates)
   const mutation = `mutation {
       upsertProfiles(
-        subAdvertiserId: ${advertiserId},
-        externalProvider: "segmentio",
-        profiles: ${JSON.stringify(profileUpdates).replace(/"([^"]+)":/g, '$1:') /* Remove quotes around keys */}
+        advertiserId: ${advertiserId},
+        externalProvider: "${EXTERNAL_PROVIDER}",
+        syncId: "${sha256hash(profiles)}",
+        profiles: "${profiles}"
       ) {
-        success
+        userErrors {
+          message
+        }
+      }
+      upsertProfileMapping(
+        input: {
+          advertiserId: ${advertiserId},
+          mappingSchema: "${getProfileMappings(Array.from(fieldsToMap), fieldTypes)}",
+          mappableType: "${EXTERNAL_PROVIDER}",
+        }
+      ) {
+        userErrors {
+          message
+        }
+      }
+      upsertExternalAudienceMapping(
+        input: {
+          advertiserId: ${advertiserId},
+          mappingSchema: "${audienceMapping}",
+          mappableType: "${EXTERNAL_PROVIDER}"
+        }
+      ) {
+        userErrors {
+          message
+        }
       }
     }`
   return await request(domain, {
     body: JSON.stringify({ query: mutation })
   })
+}
+
+function getProfileMappings(customFields: string[], fieldTypes: Record<string, string>) {
+  const mappingSchema: Mapping[] = []
+  for (const field of customFields) {
+    mappingSchema.push({
+      incoming_key: field,
+      destination_key: field,
+      data_type: fieldTypes[field] ?? 'string',
+      is_pii: false
+    })
+  }
+  return stringifyJsonWithEscapedQuotes(mappingSchema)
+}
+
+function stringifyJsonWithEscapedQuotes(value: unknown) {
+  return JSON.stringify(value).replace(/"/g, '\\"')
+}
+
+function sha256hash(data: string) {
+  const hash = createHash('sha256')
+  hash.update(data)
+  return hash.digest('hex')
+}
+
+function getType(value: unknown) {
+  if (value instanceof Date) return 'date'
+  return typeof value
 }
 
 // From https://www.30secondsofcode.org/js/s/string-case-conversion/

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -26,12 +26,12 @@ const standardFields = new Set([
 const audienceMapping = stringifyJsonWithEscapedQuotes([
   {
     incoming_key: 'audienceId',
-    destination_key: 'AudienceID',
+    destination_key: 'external_id',
     data_type: 'string'
   },
   {
     incoming_key: 'audienceName',
-    destination_key: 'AudienceName',
+    destination_key: 'name',
     data_type: 'string'
   }
 ])

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/postMessage/__tests__/index.test.ts
@@ -1,9 +1,0 @@
-// import nock from 'nock'
-// import { createTestEvent, createTestIntegration } from '@segment/actions-core'
-// import Destination from '../../index'
-
-// const testDestination = createTestIntegration(Destination)
-
-// describe('StackadaptAudiences.postMessage', () => {
-//   // TODO: Test your action
-// })


### PR DESCRIPTION
- Included calls to `upsertProfileMapping` and `upsertAudienceMapping` in the Segment destination.
- `upsertProfileMapping` will include any field that is not a standard field (or `previousId` which is not stored)

## Testing

- Verified updates to snapshot tests
- Tested the `upsertProfileMapping` and `upsertAudienceMapping` mutations in GraphIQL:
    - ![image](https://github.com/user-attachments/assets/e516f198-ea41-4038-9175-ad8d3c22497a)

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
