### PR TITLE
Migrate stackadapt segment engage destination to use mappingSchemaV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,6 @@
   },
   "dependencies": {
     "chance": "^1.1.8"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha512.ff4579ab459bb25aa7c0ff75b62acebe576f6084b36aa842971cf250a5d8c6cd3bc9420b22ce63c7f93a0857bc6ef29291db39c3e7a23aab5adfd5a4dd6c5d71"
 }

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/__tests__/setConfigurationFields.test.ts
@@ -806,4 +806,36 @@ describe('Set Configuration Fields action', () => {
       send_page_view: false
     })
   })
+
+  it('should convert consent values to lower case', async () => {
+    defaultSettings.enableConsentMode = true
+
+    const [setConfigurationEventPlugin] = await googleAnalytics4Web({
+      ...defaultSettings,
+      subscriptions
+    })
+    setConfigurationEvent = setConfigurationEventPlugin
+    await setConfigurationEventPlugin.load(Context.system(), {} as Analytics)
+
+    const context = new Context({
+      event: 'setConfigurationFields',
+      type: 'page',
+      properties: {
+        ads_storage_consent_state: 'GRANTED',
+        analytics_storage_consent_state: 'Granted'
+      }
+    })
+
+    setConfigurationEvent.page?.(context)
+
+    expect(mockGtag).toHaveBeenCalledWith('consent', 'update', {
+      ad_storage: 'granted',
+      analytics_storage: 'granted'
+    })
+    expect(mockGtag).toHaveBeenCalledWith('config', 'G-XXXXXXXXXX', {
+      allow_ad_personalization_signals: false,
+      allow_google_signals: false,
+      send_page_view: true
+    })
+  })
 })

--- a/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
+++ b/packages/browser-destinations/destinations/google-analytics-4-web/src/setConfigurationFields/index.ts
@@ -20,13 +20,23 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
       description:
         'Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.',
       label: 'Ads Storage Consent State',
-      type: 'string'
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
     },
     analytics_storage_consent_state: {
       description:
         'Consent state indicated by the user for ad cookies. Value must be “granted” or “denied.” This is only used if the Enable Consent Mode setting is on.',
       label: 'Analytics Storage Consent State',
-      type: 'string'
+      type: 'string',
+      choices: [
+        { label: 'Granted', value: 'granted' },
+        { label: 'Denied', value: 'denied' }
+      ],
+      default: undefined
     },
     ad_user_data_consent_state: {
       description:
@@ -140,10 +150,10 @@ const action: BrowserActionDefinition<Settings, Function, Payload> = {
         ad_personalization?: ConsentParamsArg
       } = {}
       if (payload.ads_storage_consent_state) {
-        consentParams.ad_storage = payload.ads_storage_consent_state as ConsentParamsArg
+        consentParams.ad_storage = payload.ads_storage_consent_state.toLowerCase() as ConsentParamsArg
       }
       if (payload.analytics_storage_consent_state) {
-        consentParams.analytics_storage = payload.analytics_storage_consent_state as ConsentParamsArg
+        consentParams.analytics_storage = payload.analytics_storage_consent_state.toLowerCase() as ConsentParamsArg
       }
       if (payload.ad_user_data_consent_state) {
         consentParams.ad_user_data = payload.ad_user_data_consent_state as ConsentParamsArg

--- a/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/__tests__/index.test.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/__tests__/index.test.ts
@@ -204,4 +204,52 @@ describe('Hubspot.upsertContact', () => {
       }
     ])
   })
+
+  test('trims string traits', async () => {
+    const context = new Context({
+      type: 'identify',
+      userId: 'mike',
+      traits: {
+        friendly: false,
+        email: 'mike_eh@lph.com',
+        address: {
+          street: '6th St',
+          city: '  San Francisco  ', // to be trimmed
+          state: 'CA',
+          postalCode: '94103',
+          country: 'USA'
+        },
+        equipment: {
+          type: '🚘',
+          color: '  red  ', // to be trimmed
+          make: {
+            make: 'Tesla',
+            model: 'Model S',
+            year: 2019
+          }
+        }
+      }
+    })
+
+    await upsertContactEvent.identify?.(context)
+    expect(mockHubspot.push).toHaveBeenCalledTimes(1)
+    expect(mockHubspot.push).toHaveBeenCalledWith([
+      'identify',
+      {
+        email: 'mike_eh@lph.com',
+        id: 'mike',
+        friendly: false,
+        address: '6th St',
+        country: 'USA',
+        state: 'CA',
+        city: 'San Francisco',
+        zip: '94103',
+        equipment_type: '🚘',
+        equipment_color: 'red',
+        equipment_make_make: 'Tesla',
+        equipment_make_model: 'Model S',
+        equipment_make_year: 2019
+      }
+    ])
+  })
 })

--- a/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/index.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/upsertContact/index.ts
@@ -30,7 +30,8 @@ const action: BrowserActionDefinition<Settings, Hubspot, Payload> = {
       }
     },
     custom_properties: {
-      description: 'A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.',
+      description:
+        'A list of key-value pairs that describe the contact. Please see [HubSpot`s documentation](https://knowledge.hubspot.com/account/prevent-contact-properties-update-through-tracking-code-api) for limitations in updating contact properties.',
       label: 'Custom Properties',
       type: 'object',
       required: false,
@@ -102,6 +103,15 @@ const action: BrowserActionDefinition<Settings, Hubspot, Payload> = {
     if (!payload.email) {
       return
     }
+
+    payload.email = payload.email?.trim()
+    payload.id = payload.id?.trim()
+    payload.company = payload.company?.trim()
+    payload.country = payload.country?.trim()
+    payload.state = payload.state?.trim()
+    payload.city = payload.city?.trim()
+    payload.address = payload.address?.trim()
+    payload.zip = payload.zip?.trim()
 
     // custom properties should be key-value pairs of strings, therefore, filtering out any non-primitive
     const { custom_properties, ...rest } = payload

--- a/packages/browser-destinations/destinations/hubspot-web/src/utils/flatten.ts
+++ b/packages/browser-destinations/destinations/hubspot-web/src/utils/flatten.ts
@@ -23,7 +23,9 @@ export function flatten(
       const flattened = flatten(data[key] as Properties, `${prefix}_${key}`, skipList, keyTransformation)
       result = { ...result, ...flattened }
     } else {
-      result[keyTransformation(`${prefix}_${key}`.replace(/^_/, ''))] = data[key] as JSONPrimitive
+      result[keyTransformation(`${prefix}_${key}`.replace(/^_/, ''))] = (
+        typeof data[key] === 'string' ? (data[key] as string).trim() : data[key]
+      ) as JSONPrimitive
     }
   }
   return result

--- a/packages/destination-actions/package.json
+++ b/packages/destination-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/action-destinations",
   "description": "Destination Actions engine and definitions.",
-  "version": "3.345.0",
+  "version": "3.345.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/segmentio/action-destinations",

--- a/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,24 +2,32 @@
 
 exports[`Testing snapshot for drip destination: identify action - all fields 1`] = `
 Object {
-  "custom_fields": Object {
-    "testType": "XoS!vJs",
-  },
-  "email": "mivsaj@pu.co.uk",
-  "ip_address": "33.172.51.152",
-  "sms_number": "XoS!vJs",
-  "status": "XoS!vJs",
-  "status_updated_at": "2021-02-01T00:00:00.000Z",
-  "tags": Array [
-    "XoS!vJs",
+  "subscribers": Array [
+    Object {
+      "custom_fields": Object {
+        "testType": "XoS!vJs",
+      },
+      "email": "mivsaj@pu.co.uk",
+      "ip_address": "33.172.51.152",
+      "sms_number": "XoS!vJs",
+      "status": "XoS!vJs",
+      "status_updated_at": "2021-02-01T00:00:00.000Z",
+      "tags": Array [
+        "XoS!vJs",
+      ],
+      "time_zone": "XoS!vJs",
+    },
   ],
-  "time_zone": "XoS!vJs",
 }
 `;
 
 exports[`Testing snapshot for drip destination: identify action - required fields 1`] = `
 Object {
-  "email": "mivsaj@pu.co.uk",
+  "subscribers": Array [
+    Object {
+      "email": "mivsaj@pu.co.uk",
+    },
+  ],
 }
 `;
 

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,23 +2,31 @@
 
 exports[`Testing snapshot for Drip's identify destination action: all fields 1`] = `
 Object {
-  "custom_fields": Object {
-    "testType": "DVw6A7$UK[I",
-  },
-  "email": "okavno@kulusof.bg",
-  "ip_address": "100.102.165.77",
-  "sms_number": "DVw6A7$UK[I",
-  "status": "DVw6A7$UK[I",
-  "status_updated_at": "2021-02-01T00:00:00.000Z",
-  "tags": Array [
-    "DVw6A7$UK[I",
+  "subscribers": Array [
+    Object {
+      "custom_fields": Object {
+        "testType": "DVw6A7$UK[I",
+      },
+      "email": "okavno@kulusof.bg",
+      "ip_address": "100.102.165.77",
+      "sms_number": "DVw6A7$UK[I",
+      "status": "DVw6A7$UK[I",
+      "status_updated_at": "2021-02-01T00:00:00.000Z",
+      "tags": Array [
+        "DVw6A7$UK[I",
+      ],
+      "time_zone": "DVw6A7$UK[I",
+    },
   ],
-  "time_zone": "DVw6A7$UK[I",
 }
 `;
 
 exports[`Testing snapshot for Drip's identify destination action: required fields 1`] = `
 Object {
-  "email": "okavno@kulusof.bg",
+  "subscribers": Array [
+    Object {
+      "email": "okavno@kulusof.bg",
+    },
+  ],
 }
 `;

--- a/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/__tests__/index.test.ts
@@ -24,7 +24,15 @@ describe('Drip.identify', () => {
         phone: '1234567890',
         status: 'unsubscribed',
         status_updated_at: '2021-01-01T00:00:00Z',
-        custom_fields: { fizz: 'buzz', numb:1234, bool:true, oppBool:false, arr: ["hello", 1234, false], obj: { key: 'value' }, null: null },
+        custom_fields: {
+          fizz: 'buzz',
+          numb: 1234,
+          bool: true,
+          oppBool: false,
+          arr: ['hello', 1234, false],
+          obj: { key: 'value' },
+          null: null
+        },
         tags: 'tag1,tag2'
       }
     })
@@ -36,14 +44,25 @@ describe('Drip.identify', () => {
     })
 
     const body = {
-      custom_fields: { fizz: 'buzz', numb:"1234", bool:"true", oppBool:"false", arr: "[\"hello\",1234,false]", obj: "{\"key\":\"value\"}" },
-      email: 'test@example.com',
-      ip_address: '127.0.0.1',
-      sms_number: '1234567890',
-      status: 'unsubscribed',
-      status_updated_at: '2021-01-01T00:00:00Z',
-      tags: ['tag1', 'tag2'],
-      time_zone: 'Europe/Amsterdam'
+      subscribers: [
+        {
+          custom_fields: {
+            fizz: 'buzz',
+            numb: '1234',
+            bool: 'true',
+            oppBool: 'false',
+            arr: '["hello",1234,false]',
+            obj: '{"key":"value"}'
+          },
+          email: 'test@example.com',
+          ip_address: '127.0.0.1',
+          sms_number: '1234567890',
+          status: 'unsubscribed',
+          status_updated_at: '2021-01-01T00:00:00Z',
+          tags: ['tag1', 'tag2'],
+          time_zone: 'Europe/Amsterdam'
+        }
+      ]
     }
 
     expect(responses.length).toBe(1)

--- a/packages/destination-actions/src/destinations/drip/identify/index.ts
+++ b/packages/destination-actions/src/destinations/drip/identify/index.ts
@@ -11,7 +11,7 @@ const person = (payload: Payload) => {
           .map(([key, value]) => [key, typeof value === 'object' ? JSON.stringify(value) : String(value)])
       )
       return Object.keys(result).length > 0 ? result : undefined
-    })(),    
+    })(),
     email: payload.email,
     ip_address: payload.ip,
     sms_number: payload.phone,
@@ -95,7 +95,7 @@ const action: ActionDefinition<Settings, Payload> = {
   perform: (request, { settings, payload }) => {
     return request(`https://api.getdrip.com/v2/${settings.accountId}/subscribers`, {
       method: 'POST',
-      json: person(payload)
+      json: { subscribers: [person(payload)] }
     })
   },
   performBatch: (request, { settings, payload }) => {

--- a/packages/destination-actions/src/destinations/drip/index.ts
+++ b/packages/destination-actions/src/destinations/drip/index.ts
@@ -7,7 +7,7 @@ const destination: DestinationDefinition<Settings> = {
   name: 'Drip (Actions)',
   slug: 'actions-drip',
   mode: 'cloud',
-  description: 'Send Segment events to Drip',
+  description: 'Send Segment analytics events and user profile details to Drip',
   authentication: {
     scheme: 'custom',
     fields: {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -29,7 +29,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {
@@ -59,7 +59,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -70,7 +70,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {
@@ -100,7 +100,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -130,7 +130,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
           mappableType: \\"segmentio\\",
         }
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -29,7 +29,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {
@@ -59,7 +59,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -70,7 +70,7 @@ Object {
       upsertExternalAudienceMapping(
         input: {
           advertiserId: 84GW[vK%wv2xv@UF5iy,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
+          mappingSchema: \\"[{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
           mappableType: \\"segmentio\\"
         }
       ) {
@@ -100,7 +100,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false}],
           mappableType: \\"segmentio\\",
         }
       ) {
@@ -130,7 +130,7 @@ Object {
       upsertProfileMapping(
         input: {
           advertiserId: PsAwlRv%,
-          mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+          mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false}],
           mappableType: \\"segmentio\\",
         }
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -95,7 +95,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -106,7 +106,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -169,7 +169,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -180,7 +180,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -228,7 +228,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -239,7 +239,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/__tests__/index.test.ts
@@ -95,7 +95,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -106,7 +106,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -169,7 +169,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -180,7 +180,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {
@@ -228,7 +228,7 @@ describe('forwardAudienceEvent', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false,\\\\\\"label\\\\\\":\\\\\\"External Profile ID\\\\\\"}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -239,7 +239,7 @@ describe('forwardAudienceEvent', () => {
             upsertExternalAudienceMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incoming_key\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
+                mappingSchema: \\"[{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience ID\\\\\\"},{\\\\\\"incomingKey\\\\\\":\\\\\\"audienceName\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"name\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"label\\\\\\":\\\\\\"External Audience Name\\\\\\"}]\\",
                 mappableType: \\"segmentio\\"
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -8,12 +8,14 @@ const audienceMapping = stringifyJsonWithEscapedQuotes([
   {
     incoming_key: 'audienceId',
     destination_key: 'external_id',
-    type: 'string'
+    type: 'string',
+    label: 'External Audience ID'
   },
   {
     incoming_key: 'audienceName',
     destination_key: 'name',
-    type: 'string'
+    type: 'string',
+    label: 'External Audience Name'
   }
 ])
 
@@ -22,7 +24,8 @@ const profileMapping = stringifyJsonWithEscapedQuotes([
     incoming_key: 'userId',
     destination_key: 'external_id',
     type: 'string',
-    is_pii: false
+    is_pii: false,
+    label: 'External Profile ID'
   }
 ])
 

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardAudienceEvent/functions.ts
@@ -6,14 +6,14 @@ const EXTERNAL_PROVIDER = 'segmentio'
 
 const audienceMapping = stringifyJsonWithEscapedQuotes([
   {
-    incoming_key: 'audienceId',
-    destination_key: 'external_id',
+    incomingKey: 'audienceId',
+    destinationKey: 'external_id',
     type: 'string',
     label: 'External Audience ID'
   },
   {
-    incoming_key: 'audienceName',
-    destination_key: 'name',
+    incomingKey: 'audienceName',
+    destinationKey: 'name',
     type: 'string',
     label: 'External Audience Name'
   }
@@ -21,10 +21,10 @@ const audienceMapping = stringifyJsonWithEscapedQuotes([
 
 const profileMapping = stringifyJsonWithEscapedQuotes([
   {
-    incoming_key: 'userId',
-    destination_key: 'external_id',
+    incomingKey: 'userId',
+    destinationKey: 'external_id',
     type: 'string',
-    is_pii: false,
+    isPii: false,
     label: 'External Profile ID'
   }
 ])
@@ -60,7 +60,7 @@ export async function performForwardAudienceEvents(request: RequestClient, event
       upsertProfileMapping(
         input: {
           advertiserId: ${advertiserId},
-          mappingSchema: "${profileMapping}",
+          mappingSchemaV2: ${profileMapping},
           mappableType: "${EXTERNAL_PROVIDER}",
         }
       ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -131,7 +131,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -194,7 +194,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -242,7 +242,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -290,7 +290,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
                 mappableType: \\"segmentio\\",
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/__tests__/index.test.ts
@@ -131,7 +131,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -194,7 +194,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -242,7 +242,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false},{\\\\\\"incoming_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"customField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false},{\\\\\\"incomingKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"numberCustomField\\\\\\",\\\\\\"label\\\\\\":\\\\\\"Number Custom Field\\\\\\",\\\\\\"type\\\\\\":\\\\\\"number\\\\\\",\\\\\\"isPii\\\\\\":false}],
                 mappableType: \\"segmentio\\",
               }
             ) {
@@ -290,7 +290,7 @@ describe('forwardProfile', () => {
             upsertProfileMapping(
               input: {
                 advertiserId: 23,
-                mappingSchema: \\"[{\\\\\\"incoming_key\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destination_key\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"is_pii\\\\\\":false}]\\",
+                mappingSchemaV2: [{\\\\\\"incomingKey\\\\\\":\\\\\\"userId\\\\\\",\\\\\\"destinationKey\\\\\\":\\\\\\"external_id\\\\\\",\\\\\\"label\\\\\\":\\\\\\"User Id\\\\\\",\\\\\\"type\\\\\\":\\\\\\"string\\\\\\",\\\\\\"isPii\\\\\\":false}],
                 mappableType: \\"segmentio\\",
               }
             ) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -26,6 +26,7 @@ const standardFields = new Set([
 interface Mapping {
   incoming_key: string
   destination_key: string
+  label: string
   type: string
   is_pii: boolean
 }
@@ -113,11 +114,27 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
     mappingSchema.push({
       incoming_key: field,
       destination_key: field === 'userId' ? 'external_id' : field,
+      label: generateLabel(field),
       type: fieldTypes[field] ?? 'string',
       is_pii: false
     })
   }
   return stringifyJsonWithEscapedQuotes(mappingSchema)
+}
+
+function generateLabel(field: string) {
+  // Convert camelCase to "Title Case"
+  let label = field
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    .replace(/^./, (str) => str.toUpperCase())
+
+  // Check if the input starts with "audience" and attach "External" if true
+  if (field.startsWith('audience')) {
+    label = `External ${label}`
+  }
+
+  return label
 }
 
 function getType(value: unknown) {

--- a/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
+++ b/packages/destination-actions/src/destinations/stackadapt-audiences/forwardProfile/functions.ts
@@ -24,11 +24,11 @@ const standardFields = new Set([
 ])
 
 interface Mapping {
-  incoming_key: string
-  destination_key: string
+  incomingKey: string
+  destinationKey: string
   label: string
   type: string
-  is_pii: boolean
+  isPii: boolean
 }
 
 export async function performForwardProfiles(request: RequestClient, events: Payload[]) {
@@ -73,7 +73,7 @@ export async function performForwardProfiles(request: RequestClient, events: Pay
       upsertProfileMapping(
         input: {
           advertiserId: ${advertiserId},
-          mappingSchema: "${getProfileMappings(Array.from(fieldsToMap), fieldTypes)}",
+          mappingSchemaV2: ${getProfileMappings(Array.from(fieldsToMap), fieldTypes)},
           mappableType: "${EXTERNAL_PROVIDER}",
         }
       ) {
@@ -112,11 +112,11 @@ function getProfileMappings(customFields: string[], fieldTypes: Record<string, s
   const mappingSchema: Mapping[] = []
   for (const field of customFields) {
     mappingSchema.push({
-      incoming_key: field,
-      destination_key: field === 'userId' ? 'external_id' : field,
+      incomingKey: field,
+      destinationKey: field === 'userId' ? 'external_id' : field,
       label: generateLabel(field),
       type: fieldTypes[field] ?? 'string',
-      is_pii: false
+      isPii: false
     })
   }
   return stringifyJsonWithEscapedQuotes(mappingSchema)


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

_A summary of your pull request, including the what change you're making and why._

When calling upsertProfileMapping mutation, there's an argument mapping_schema which takes a JSON blob. We are migrating it to mapping_schema_v2. It has defined GQL types for better validation and security.
It won't cause any issue if you keep using mapping_schema, but we want to deprecate mapping_schema at some point.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [ ] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [If destination is already live] Tested for backward compatibility of destination. **Note:** New required fields are a breaking change.
- [ ] [Segmenters] Tested in the staging environment
- [ ] [Segmenters] [If applicable for this change] Tested for regression with Hadron. 
